### PR TITLE
Bug fix/confirm btn mult binds

### DIFF
--- a/views/partials/accept-form.handlebars
+++ b/views/partials/accept-form.handlebars
@@ -59,4 +59,3 @@
     </div>
   </form>
 </dialog>
-<script src="/js/confirm-btn.js"></script>

--- a/views/queue.handlebars
+++ b/views/queue.handlebars
@@ -55,3 +55,4 @@
 
 <script src="/js/decline-btn.js"></script>
 <script src="/js/approve-btn.js"></script>
+<script src="/js/confirm-btn.js"></script>


### PR DESCRIPTION
Moving the confirm button script include out of the partial to prevent the event listener from being bound multiple times